### PR TITLE
PayloadBufferController Leak

### DIFF
--- a/router/handler_xgress/bind.go
+++ b/router/handler_xgress/bind.go
@@ -43,10 +43,12 @@ func (bindHandler *bindHandler) HandleXgressBind(sessionId *identity.TokenId, ad
 	x.SetReceiveHandler(bindHandler.receiveHandler)
 	x.AddPeekHandler(bindHandler.metricsPeekHandler)
 
-	payloadBuffer := bindHandler.forwarder.PayloadBuffer(sessionId, address)
-	payloadBuffer.Originator = originator
-	payloadBuffer.SrcAddress = address
-	x.SetPayloadBuffer(payloadBuffer)
+	if x.Options.Retransmission {
+		payloadBuffer := bindHandler.forwarder.PayloadBuffer(sessionId, address)
+		payloadBuffer.Originator = originator
+		payloadBuffer.SrcAddress = address
+		x.SetPayloadBuffer(payloadBuffer)
+	}
 
 	x.SetCloseHandler(bindHandler.closeHandler)
 

--- a/router/xgress/payload_buffer.go
+++ b/router/xgress/payload_buffer.go
@@ -69,10 +69,10 @@ func (controller *PayloadBufferController) BufferForSession(sessionId *identity.
 
 func (controller *PayloadBufferController) EndSession(sessionId *identity.TokenId) {
 	if v, found := controller.sessions.Get(sessionId.Token); found {
-		logrus.Infof("cleaning up for [s/%s]", sessionId.Token)
+		logrus.Debugf("cleaning up for [s/%s]", sessionId.Token)
 		bufferIds := v.([]string)
 		for _, bufferId := range bufferIds {
-			logrus.Infof("removing bufferId [%s]", bufferId)
+			logrus.Debugf("removing bufferId [%s]", bufferId)
 			controller.buffers.Remove(bufferId)
 		}
 		controller.sessions.Remove(sessionId.Token)
@@ -171,8 +171,8 @@ func (buffer *PayloadBuffer) Close() {
 
 func (buffer *PayloadBuffer) run() {
 	log := pfxlog.ContextLogger("s/" + buffer.sessionId.Token)
-	defer log.Infof("[%p] exited", buffer)
-	log.Infof("[%p] started", buffer)
+	defer log.Debugf("[%p] exited", buffer)
+	log.Debugf("[%p] started", buffer)
 
 	lastDebug := info.NowInMilliseconds()
 	for {

--- a/router/xgress/payload_buffer.go
+++ b/router/xgress/payload_buffer.go
@@ -158,7 +158,7 @@ func (buffer *PayloadBuffer) ReceiveAcknowledgement(ack *Acknowledgement) {
 }
 
 func (buffer *PayloadBuffer) Close() {
-	logrus.Infof("[%p] closing", buffer)
+	logrus.Debugf("[%p] closing", buffer)
 	defer func() {
 		if r := recover(); r != nil {
 			pfxlog.Logger().Debug("already closed")

--- a/router/xgress/payload_buffer.go
+++ b/router/xgress/payload_buffer.go
@@ -54,16 +54,15 @@ func (controller *PayloadBufferController) BufferForSession(sessionId *identity.
 
 	buffer := NewPayloadBuffer(sessionId, controller.forwarder)
 	controller.buffers.Set(bufferId, buffer)
+	controller.sessions.Upsert(sessionId.Token, bufferId, func(exists bool, valueInMap interface{}, newValue interface{}) interface{} {
+		nv := newValue.(string)
+		if !exists {
+			return []string{nv}
+		}
+		res := valueInMap.([]string)
+		return append(res, nv)
+	})
 
-	v, found := controller.sessions.Get(sessionId.Token)
-	if found {
-		bufferIds := v.([]string)
-		bufferIds = append(bufferIds, bufferId)
-		controller.sessions.Set(sessionId.Token, bufferIds)
-	} else {
-		bufferIds := []string{bufferId}
-		controller.sessions.Set(sessionId.Token, bufferIds)
-	}
 	return buffer
 }
 

--- a/router/xgress/payload_buffer.go
+++ b/router/xgress/payload_buffer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openziti/foundation/identity/identity"
 	"github.com/openziti/foundation/util/info"
 	"github.com/orcaman/concurrent-map"
+	"github.com/sirupsen/logrus"
 	"time"
 )
 
@@ -140,6 +141,7 @@ func (buffer *PayloadBuffer) ReceiveAcknowledgement(ack *Acknowledgement) {
 }
 
 func (buffer *PayloadBuffer) Close() {
+	logrus.Infof("[%p] closing", buffer)
 	defer func() {
 		if r := recover(); r != nil {
 			pfxlog.Logger().Debug("already closed")
@@ -152,8 +154,8 @@ func (buffer *PayloadBuffer) Close() {
 
 func (buffer *PayloadBuffer) run() {
 	log := pfxlog.ContextLogger("s/" + buffer.sessionId.Token)
-	defer log.Debug("exited")
-	log.Debug("started")
+	defer log.Infof("[%p] exited", buffer)
+	log.Infof("[%p] started", buffer)
 
 	lastDebug := info.NowInMilliseconds()
 	for {

--- a/router/xgress/payload_buffer.go
+++ b/router/xgress/payload_buffer.go
@@ -39,22 +39,10 @@ type PayloadBufferController struct {
 }
 
 func NewPayloadBufferController(forwarder PayloadBufferForwarder) *PayloadBufferController {
-	pbc := &PayloadBufferController{
+	return &PayloadBufferController{
 		buffers:   cmap.New(),
 		sessions:  cmap.New(),
 		forwarder: forwarder,
-	}
-	go pbc.debug()
-	return pbc
-}
-
-func (controller *PayloadBufferController) debug() {
-	for {
-		time.Sleep(15 * time.Second)
-		logrus.Infof("buffers = [%d]", len(controller.buffers.Keys()))
-		for _, k := range controller.buffers.Keys() {
-			logrus.Infof("k = [%s]", k)
-		}
 	}
 }
 

--- a/router/xgress/payload_buffer.go
+++ b/router/xgress/payload_buffer.go
@@ -52,7 +52,7 @@ func (controller *PayloadBufferController) BufferForSession(sessionId *identity.
 		return i.(*PayloadBuffer)
 	}
 
-	buffer := NewPayloadBuffer(controller, sessionId, controller.forwarder)
+	buffer := NewPayloadBuffer(sessionId, controller.forwarder)
 	controller.buffers.Set(bufferId, buffer)
 
 	v, found := controller.sessions.Get(sessionId.Token)
@@ -91,7 +91,6 @@ type PayloadBuffer struct {
 	forwarder         PayloadBufferForwarder
 	SrcAddress        Address
 	Originator        Originator
-	controller        *PayloadBufferController
 
 	config struct {
 		retransmitAge int64
@@ -106,7 +105,7 @@ type payloadAge struct {
 	age     int64
 }
 
-func NewPayloadBuffer(controller *PayloadBufferController, sessionId *identity.TokenId, forwarder PayloadBufferForwarder) *PayloadBuffer {
+func NewPayloadBuffer(sessionId *identity.TokenId, forwarder PayloadBufferForwarder) *PayloadBuffer {
 	buffer := &PayloadBuffer{
 		sessionId:         sessionId,
 		buffer:            make(map[int32]*payloadAge),
@@ -117,7 +116,6 @@ func NewPayloadBuffer(controller *PayloadBufferController, sessionId *identity.T
 		newlyReceivedAcks: make(chan *Acknowledgement),
 		receivedAckHwm:    -1,
 		forwarder:         forwarder,
-		controller:        controller,
 	}
 
 	buffer.config.retransmitAge = 2000

--- a/router/xgress/xgress.go
+++ b/router/xgress/xgress.go
@@ -341,7 +341,7 @@ func (self *Xgress) rx() {
 				payloadLogger := log.WithFields(payload.GetLoggerFields())
 
 				if self.Options.Retransmission && self.payloadBuffer != nil {
-					payloadLogger.Info("buffering payload")
+					//payloadLogger.Debug("buffering payload")
 					self.payloadBuffer.BufferPayload(payload)
 				}
 

--- a/router/xgress/xgress.go
+++ b/router/xgress/xgress.go
@@ -95,7 +95,7 @@ type Xgress struct {
 	address        Address
 	peer           Connection
 	originator     Originator
-	options        *Options
+	Options        *Options
 	txQueue        chan *Payload
 	txBuffer       *TransmitBuffer
 	rxSequence     int32
@@ -113,7 +113,7 @@ func NewXgress(sessionId *identity.TokenId, address Address, peer Connection, or
 		address:    address,
 		peer:       peer,
 		originator: originator,
-		options:    options,
+		Options:    options,
 		txQueue:    make(chan *Payload),
 		txBuffer:   NewTransmitBuffer(),
 		rxSequence: 0,
@@ -188,7 +188,7 @@ func (self *Xgress) Close() {
 		log.Debug("closing tx queue")
 		close(self.txQueue)
 
-		if self.options.Retransmission && self.payloadBuffer != nil {
+		if self.Options.Retransmission && self.payloadBuffer != nil {
 			self.payloadBuffer.Close()
 		}
 
@@ -231,7 +231,7 @@ func (self *Xgress) SendPayload(payload *Payload) error {
 }
 
 func (self *Xgress) SendAcknowledgement(acknowledgement *Acknowledgement) error {
-	if self.options.Retransmission && self.payloadBuffer != nil {
+	if self.Options.Retransmission && self.payloadBuffer != nil {
 		// if we have xgress <-> xgress in a single router, they will share a Payload buffer, as they share
 		// a session and can get caught in deadlock if we don't dispatch to a new goroutine here
 		go self.payloadBuffer.ReceiveAcknowledgement(acknowledgement)
@@ -250,10 +250,10 @@ func (self *Xgress) tx() {
 		case inPayload := <-self.txQueue:
 			if inPayload != nil && !inPayload.IsSessionEndFlagSet() {
 				payloadLogger := log.WithFields(inPayload.GetLoggerFields())
-				if !self.options.RandomDrops || rand.Int31n(self.options.Drop1InN) != 1 {
+				if !self.Options.RandomDrops || rand.Int31n(self.Options.Drop1InN) != 1 {
 					payloadLogger.Debug("adding to transmit buffer")
 					self.txBuffer.ReceiveUnordered(inPayload)
-					if self.options.Retransmission && self.payloadBuffer != nil {
+					if self.Options.Retransmission && self.payloadBuffer != nil {
 						payloadLogger.Debug("acknowledging")
 						self.payloadBuffer.AcknowledgePayload(inPayload)
 					}
@@ -324,7 +324,7 @@ func (self *Xgress) rx() {
 			remaining := n
 			payloads := 0
 			for remaining > 0 {
-				length := mathz.MinInt(remaining, int(self.options.Mtu))
+				length := mathz.MinInt(remaining, int(self.Options.Mtu))
 				payload := &Payload{
 					Header: Header{
 						SessionId: self.sessionId.Token,
@@ -340,8 +340,8 @@ func (self *Xgress) rx() {
 
 				payloadLogger := log.WithFields(payload.GetLoggerFields())
 
-				if self.options.Retransmission && self.payloadBuffer != nil {
-					payloadLogger.Debug("buffering payload")
+				if self.Options.Retransmission && self.payloadBuffer != nil {
+					payloadLogger.Info("buffering payload")
 					self.payloadBuffer.BufferPayload(payload)
 				}
 


### PR DESCRIPTION
`PayloadBufferController.EndSession` was not properly cleaning up `PayloadBuffer` instances at session end, causing any `Payload` references inside the `PayloadBuffer` to just sit around (leak).

This may have started around the time we enabled support for single-router operation, because it looks like we're indexing `PayloadBuffer` instances by `address`+`sessionId` instead of just `sessionId` (necessary to support 2 `PayloadBuffer` instances for a single session in a single router. When the change was made, it looks like `EndSession` was left to try and remove `PayloadBuffer` instances by just `sessionId`, which wasn't removing anything.

Added an additional `cmap.ConcurrentMap` index called `sessions` to track `bindingId`s (`address`+`sessionId`) for each session, allowing `EndSession` to easily retrieve the list of `bindingId`s that need to be cleaned up.

Also adjusted `handler_xgress.BindHandler` to respect the `retransmission` option, and not create a `PayloadBuffer` for an Xgress if retransmission is disabled.