### PR TITLE
64k default MTU

### DIFF
--- a/router/xgress/options.go
+++ b/router/xgress/options.go
@@ -53,7 +53,7 @@ func LoadOptions(data OptionsData) *Options {
 
 func DefaultOptions() *Options {
 	return &Options{
-		Mtu:            16384,
+		Mtu:            64 * 1024,
 		Retransmission: true,
 		RandomDrops:    false,
 		Drop1InN:       100,


### PR DESCRIPTION
Set the default "MTU" to 64k. This is the upper buffer size limit. Sending a larger data payload than this size will result in multiple `Payload` messages being transmitted across the fabric. Moving to a 64k default to better align with standardized buffer/packet sizes for up/down stream integrations.

Xgress implementations have the `xgress.Optons.Mtu` value available to interrogate the configured MTU size.