### PR TITLE
Configurable xgress.GetSession Timeout

### DIFF
--- a/router/xgress/options.go
+++ b/router/xgress/options.go
@@ -18,6 +18,7 @@ package xgress
 
 import (
 	"encoding/json"
+	"github.com/pkg/errors"
 	"time"
 )
 
@@ -43,9 +44,11 @@ type Options struct {
 	RetxScale    float64
 	RetxAddMs    uint32
 	MaxCloseWait time.Duration
+
+	GetSessionTimeout time.Duration
 }
 
-func LoadOptions(data OptionsData) *Options {
+func LoadOptions(data OptionsData) (*Options, error) {
 	options := DefaultOptions()
 
 	if value, found := data["options"]; found {
@@ -108,9 +111,16 @@ func LoadOptions(data OptionsData) *Options {
 			options.MaxCloseWait = time.Duration(value.(int)) * time.Millisecond
 		}
 
+		if value, found := data["getSessionTimeout"]; found {
+			getSessionTimeout, err := time.ParseDuration(value.(string))
+			if err != nil {
+				return nil, errors.Wrap(err, "invalid 'getSessionTimeout' value")
+			}
+			options.GetSessionTimeout = getSessionTimeout
+		}
 	}
 
-	return options
+	return options, nil
 }
 
 func DefaultOptions() *Options {
@@ -133,6 +143,7 @@ func DefaultOptions() *Options {
 		RetxScale:              2.0,
 		RetxAddMs:              100,
 		MaxCloseWait:           30 * time.Second,
+		GetSessionTimeout:      30 * time.Second,
 	}
 }
 

--- a/router/xgress/request.go
+++ b/router/xgress/request.go
@@ -136,7 +136,7 @@ type SessionInfo struct {
 
 var authError = errors.New("unexpected failure while authenticating")
 
-func GetSession(ctrl CtrlChannel, ingressId string, serviceId string, peerData map[uint32][]byte) (*SessionInfo, error) {
+func GetSession(ctrl CtrlChannel, ingressId string, serviceId string, timeout time.Duration, peerData map[uint32][]byte) (*SessionInfo, error) {
 	log := pfxlog.Logger()
 	sessionRequest := &ctrl_pb.SessionRequest{
 		IngressId: ingressId,
@@ -150,7 +150,7 @@ func GetSession(ctrl CtrlChannel, ingressId string, serviceId string, peerData m
 	}
 
 	msg := channel2.NewMessage(int32(ctrl_pb.ContentType_SessionRequestType), bytes)
-	reply, err := ctrl.Channel().SendAndWaitWithTimeout(msg, time.Second*5)
+	reply, err := ctrl.Channel().SendAndWaitWithTimeout(msg, timeout)
 	if err != nil {
 		log.Errorf("failed to send SessionRequest message: (%v)", err)
 		return nil, authError
@@ -187,7 +187,7 @@ func GetSession(ctrl CtrlChannel, ingressId string, serviceId string, peerData m
 }
 
 func CreateSession(ctrl CtrlChannel, peer Connection, request *Request, bindHandler BindHandler, options *Options) *Response {
-	sessionInfo, err := GetSession(ctrl, request.Id, request.ServiceId, nil)
+	sessionInfo, err := GetSession(ctrl, request.Id, request.ServiceId, options.GetSessionTimeout, nil)
 	if err != nil {
 		return &Response{Success: false, Message: err.Error()}
 	}

--- a/router/xgress_proxy/factory.go
+++ b/router/xgress_proxy/factory.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openziti/fabric/router/xgress"
 	"github.com/openziti/foundation/identity/identity"
 	"github.com/openziti/foundation/transport"
+	"github.com/pkg/errors"
 )
 
 func NewFactory(id *identity.TokenId, ctrl xgress.CtrlChannel, tcfg transport.Configuration) xgress.Factory {
@@ -28,7 +29,10 @@ func NewFactory(id *identity.TokenId, ctrl xgress.CtrlChannel, tcfg transport.Co
 }
 
 func (factory *factory) CreateListener(optionsData xgress.OptionsData) (xgress.Listener, error) {
-	options := xgress.LoadOptions(optionsData)
+	options, err := xgress.LoadOptions(optionsData)
+	if err != nil {
+		return nil, errors.Wrap(err, "error loading options")
+	}
 	service := ""
 	if value, found := optionsData["service"]; found {
 		service = value.(string)

--- a/router/xgress_proxy_udp/factory.go
+++ b/router/xgress_proxy_udp/factory.go
@@ -19,6 +19,7 @@ package xgress_proxy_udp
 import (
 	"fmt"
 	"github.com/openziti/fabric/router/xgress"
+	"github.com/pkg/errors"
 )
 
 func NewFactory(ctrl xgress.CtrlChannel) xgress.Factory {
@@ -26,7 +27,10 @@ func NewFactory(ctrl xgress.CtrlChannel) xgress.Factory {
 }
 
 func (f *factory) CreateListener(optionsData xgress.OptionsData) (xgress.Listener, error) {
-	options := xgress.LoadOptions(optionsData)
+	options, err := xgress.LoadOptions(optionsData)
+	if err != nil {
+		return nil, errors.Wrap(err, "error loading options")
+	}
 	service := ""
 	if value, found := optionsData["service"]; found {
 		service = value.(string)

--- a/router/xgress_transport/factory.go
+++ b/router/xgress_transport/factory.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openziti/fabric/router/xgress"
 	"github.com/openziti/foundation/identity/identity"
 	"github.com/openziti/foundation/transport"
+	"github.com/pkg/errors"
 )
 
 type factory struct {
@@ -35,11 +36,17 @@ func NewFactory(id *identity.TokenId, ctrl xgress.CtrlChannel, tcfg transport.Co
 }
 
 func (factory *factory) CreateListener(optionsData xgress.OptionsData) (xgress.Listener, error) {
-	options := xgress.LoadOptions(optionsData)
+	options, err := xgress.LoadOptions(optionsData)
+	if err != nil {
+		return nil, errors.Wrap(err, "error loading options")
+	}
 	return newListener(factory.id, factory.ctrl, options, factory.tcfg), nil
 }
 
 func (factory *factory) CreateDialer(optionsData xgress.OptionsData) (xgress.Dialer, error) {
-	options := xgress.LoadOptions(optionsData)
+	options, err := xgress.LoadOptions(optionsData)
+	if err != nil {
+		return nil, errors.Wrap(err, "error loading options")
+	}
 	return newDialer(factory.id, factory.ctrl, options, factory.tcfg)
 }

--- a/router/xgress_transport_udp/factory.go
+++ b/router/xgress_transport_udp/factory.go
@@ -19,6 +19,7 @@ package xgress_transport_udp
 import (
 	"github.com/openziti/fabric/router/xgress"
 	"github.com/openziti/foundation/identity/identity"
+	"github.com/pkg/errors"
 )
 
 func NewFactory(id *identity.TokenId, ctrl xgress.CtrlChannel) xgress.Factory {
@@ -26,12 +27,18 @@ func NewFactory(id *identity.TokenId, ctrl xgress.CtrlChannel) xgress.Factory {
 }
 
 func (factory *factory) CreateListener(optionsData xgress.OptionsData) (xgress.Listener, error) {
-	options := xgress.LoadOptions(optionsData)
+	options, err := xgress.LoadOptions(optionsData)
+	if err != nil {
+		return nil, errors.Wrap(err, "error loading options")
+	}
 	return newListener(factory.id, factory.ctrl, options), nil
 }
 
 func (factory *factory) CreateDialer(optionsData xgress.OptionsData) (xgress.Dialer, error) {
-	options := xgress.LoadOptions(optionsData)
+	options, err := xgress.LoadOptions(optionsData)
+	if err != nil {
+		return nil, errors.Wrap(err, "error loading options")
+	}
 	return newDialer(factory.id, factory.ctrl, options)
 }
 


### PR DESCRIPTION
Remove the hard-coded 5 second timeout from `xgress.GetSession`, making it configurable in `xgress.Options`.