### PR TITLE
Add interval counts, per service, for dial success, timeout, fail, other

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -125,7 +125,7 @@ func (c *Controller) Run() error {
 	/* */
 
 	// event handlers
-	if err := events.WireEventHandlers(); err != nil {
+	if err := events.WireEventHandlers(c.network.InitServiceCounterDispatch); err != nil {
 		panic(err)
 	}
 

--- a/controller/network/service_counters.go
+++ b/controller/network/service_counters.go
@@ -1,0 +1,26 @@
+package network
+
+import "time"
+
+type ServiceCounters interface {
+	ServiceDialSuccess(serviceId string)
+	ServiceDialFail(serviceId string)
+	ServiceDialTimeout(serviceId string)
+	ServiceDialOtherError(serviceId string)
+}
+
+func (network *Network) ServiceDialSuccess(serviceId string) {
+	network.serviceDialSuccessCounter.Update(serviceId, time.Now(), 1)
+}
+
+func (network *Network) ServiceDialFail(serviceId string) {
+	network.serviceDialFailCounter.Update(serviceId, time.Now(), 1)
+}
+
+func (network *Network) ServiceDialTimeout(serviceId string) {
+	network.serviceDialTimeoutCounter.Update(serviceId, time.Now(), 1)
+}
+
+func (network *Network) ServiceDialOtherError(serviceId string) {
+	network.serviceDialOtherErrorCounter.Update(serviceId, time.Now(), 1)
+}

--- a/events/formatter.go
+++ b/events/formatter.go
@@ -96,6 +96,17 @@ func (event *JsonUsageEvent) WriteTo(output io.WriteCloser) error {
 	return err
 }
 
+type JsonServiceEvent ServiceEvent
+
+func (event *JsonServiceEvent) WriteTo(output io.WriteCloser) error {
+	buf, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	_, err = output.Write(buf)
+	return err
+}
+
 type JsonTerminatorEvent TerminatorEvent
 
 func (event *JsonTerminatorEvent) WriteTo(output io.WriteCloser) error {
@@ -132,6 +143,10 @@ func (formatter *JsonFormatter) AcceptUsageEvent(event *UsageEvent) {
 	formatter.AcceptLoggingEvent((*JsonUsageEvent)(event))
 }
 
+func (formatter *JsonFormatter) AcceptServiceEvent(event *ServiceEvent) {
+	formatter.AcceptLoggingEvent((*JsonServiceEvent)(event))
+}
+
 func (formatter *JsonFormatter) AcceptTerminatorEvent(event *TerminatorEvent) {
 	formatter.AcceptLoggingEvent((*JsonTerminatorEvent)(event))
 }
@@ -165,6 +180,13 @@ func (event *PlainTextUsageEvent) WriteTo(output io.WriteCloser) error {
 	return err
 }
 
+type PlainTextServiceEvent ServiceEvent
+
+func (event *PlainTextServiceEvent) WriteTo(output io.WriteCloser) error {
+	_, err := output.Write([]byte((*ServiceEvent)(event).String()))
+	return err
+}
+
 type PlainTextTerminatorEvent TerminatorEvent
 
 func (event *PlainTextTerminatorEvent) WriteTo(output io.WriteCloser) error {
@@ -195,6 +217,10 @@ func (formatter *PlainTextFormatter) AcceptMetricsEvent(event *MetricsEvent) {
 
 func (formatter *PlainTextFormatter) AcceptUsageEvent(event *UsageEvent) {
 	formatter.AcceptLoggingEvent((*PlainTextUsageEvent)(event))
+}
+
+func (formatter *PlainTextFormatter) AcceptServiceEvent(event *ServiceEvent) {
+	formatter.AcceptLoggingEvent((*PlainTextServiceEvent)(event))
 }
 
 func (formatter *PlainTextFormatter) AcceptTerminatorEvent(event *TerminatorEvent) {

--- a/events/global_registry.go
+++ b/events/global_registry.go
@@ -3,6 +3,7 @@ package events
 import (
 	"fmt"
 	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/foundation/metrics"
 	"github.com/pkg/errors"
 	"strings"
 	"sync"
@@ -136,9 +137,12 @@ events:
       path: /tmp/ziti-events.log
 
 */
-func WireEventHandlers() error {
+func WireEventHandlers(serviceEventInitializer func(handler metrics.Handler)) error {
 	registryLock.Lock()
 	defer registryLock.Unlock()
+
+	serviceEventInitializer(serviceEventAdapter{})
+
 	logger := pfxlog.Logger()
 	for _, eventHandlerConfig := range eventHandlerConfigs {
 		handler, err := eventHandlerConfig.createHandler()

--- a/events/registrations.go
+++ b/events/registrations.go
@@ -10,6 +10,7 @@ import (
 
 func init() {
 	RegisterEventType("metrics", registerMetricsEventHandler)
+	RegisterEventType("services", registerServiceEventHandler)
 	RegisterEventType("fabric.usage", registerUsageEventHandler)
 	RegisterEventType("fabric.sessions", registerSessionEventHandler)
 	RegisterEventType("fabric.terminators", registerTerminatorEventHandler)
@@ -45,4 +46,12 @@ func AddTerminatorEventHandler(handler TerminatorEventHandler) {
 
 func RemoveTerminatorEventHandler(handler TerminatorEventHandler) {
 	cowslice.Delete(terminatorEventHandlerRegistry, handler)
+}
+
+func AddServiceEventHandler(handler ServiceEventHandler) {
+	cowslice.Append(serviceEventHandlerRegistry, handler)
+}
+
+func RemoveServiceEventHandler(handler ServiceEventHandler) {
+	cowslice.Delete(serviceEventHandlerRegistry, handler)
 }

--- a/events/service_events.go
+++ b/events/service_events.go
@@ -1,0 +1,69 @@
+package events
+
+import (
+	"fmt"
+	"github.com/openziti/foundation/metrics/metrics_pb"
+	"github.com/openziti/foundation/util/cowslice"
+	"github.com/pkg/errors"
+	"reflect"
+)
+
+func registerServiceEventHandler(val interface{}, _ map[interface{}]interface{}) error {
+	handler, ok := val.(ServiceEventHandler)
+	if !ok {
+		return errors.Errorf("type %v doesn't implement github.com/openziti/fabric/events/ServiceEventHandler interface.", reflect.TypeOf(val))
+	}
+
+	AddServiceEventHandler(handler)
+	return nil
+}
+
+var serviceEventHandlerRegistry = cowslice.NewCowSlice(make([]ServiceEventHandler, 0))
+
+func getServiceEventHandlers() []ServiceEventHandler {
+	return serviceEventHandlerRegistry.Value().([]ServiceEventHandler)
+}
+
+type serviceEventAdapter struct{}
+
+func (self serviceEventAdapter) AcceptMetrics(message *metrics_pb.MetricsMessage) {
+	for name, interval := range message.IntervalCounters {
+		for _, bucket := range interval.Buckets {
+			for serviceId, count := range bucket.Values {
+				event := &ServiceEvent{
+					Namespace:        "service.events",
+					EventType:        name,
+					ServiceId:        serviceId,
+					Count:            count,
+					IntervalStartUTC: bucket.IntervalStartUTC,
+					IntervalLength:   interval.IntervalLength,
+				}
+				self.dispatchEvent(event)
+			}
+		}
+	}
+}
+
+func (self serviceEventAdapter) dispatchEvent(event *ServiceEvent) {
+	for _, handler := range getServiceEventHandlers() {
+		handler.AcceptServiceEvent(event)
+	}
+}
+
+type ServiceEvent struct {
+	Namespace        string `json:"namespace"`
+	EventType        string `json:"event_type"`
+	ServiceId        string `json:"service_id"`
+	Count            uint64 `json:"count"`
+	IntervalStartUTC int64  `json:"interval_start_utc"`
+	IntervalLength   uint64 `json:"interval_length"`
+}
+
+func (event *ServiceEvent) String() string {
+	return fmt.Sprintf("%v service=%v count=%v intervalStart=%v intervalLength=%v",
+		event.EventType, event.ServiceId, event.Count, event.IntervalStartUTC, event.IntervalLength)
+}
+
+type ServiceEventHandler interface {
+	AcceptServiceEvent(event *ServiceEvent)
+}


### PR DESCRIPTION
Can be configured as follows:

```
events:
  jsonLogger:
    subscriptions:
      - type: services
    handler:
      type: file
      format: json
      path: /tmp/ziti-events.log
```
Results in output like:

```
{
  "namespace": "service.events",
  "event_type": "service.dial.no_terminators",
  "service_id": "HSfgHzIom",
  "count": 8,
  "interval_start_utc": 1615400160,
  "interval_length": 60
}
{
  "namespace": "service.events",
  "event_type": "service.dial.success",
  "service_id": "HSfgHzIom",
  "count": 29,
  "interval_start_utc": 1615400160,
  "interval_length": 60
}
```