### PR TITLE
Allow multiple xgress close handlers

### DIFF
--- a/router/handler_xgress/bind.go
+++ b/router/handler_xgress/bind.go
@@ -42,7 +42,7 @@ func (bindHandler *bindHandler) HandleXgressBind(x *xgress.Xgress) {
 	x.SetReceiveHandler(bindHandler.receiveHandler)
 	x.AddPeekHandler(bindHandler.metricsPeekHandler)
 
-	x.SetCloseHandler(bindHandler.closeHandler)
+	x.AddCloseHandler(bindHandler.closeHandler)
 
 	bindHandler.forwarder.RegisterDestination(x.SessionId(), x.Address(), x)
 }


### PR DESCRIPTION
Provides a hook where xgress implementations can do extra cleanup when an xgress session ends