### PR TITLE
Allow way to notify router of rename

### DIFF
--- a/controller/network/network.go
+++ b/controller/network/network.go
@@ -896,6 +896,20 @@ func (network *Network) GetServiceCache() Cache {
 	return network.Services
 }
 
+func (network *Network) NotifyRouterRenamed(id, name string) {
+	if cached, _ := network.Routers.cache.Get(id); cached != nil {
+		if cachedRouter, ok := cached.(*db.Router); ok {
+			cachedRouter.Name = name
+		}
+	}
+
+	if cached, _ := network.Routers.connected.Get(id); cached != nil {
+		if cachedRouter, ok := cached.(*db.Router); ok {
+			cachedRouter.Name = name
+		}
+	}
+}
+
 var DbSnapshotTooFrequentError = dbSnapshotTooFrequentError{}
 
 type dbSnapshotTooFrequentError struct{}


### PR DESCRIPTION
@michaelquigley This is likely incomplete. I started down the path of clearing the cache on update, but we compare routers directly in some places. I started trying to fix that, but that had large ripples. I settled on this as the smallest fix and though we should tackle any bigger cleanups as part of the distributed controller work. Thoughts?