### PR TITLE
add ability to clear the cached state of a router from bbolt

### DIFF
--- a/controller/network/router.go
+++ b/controller/network/router.go
@@ -17,6 +17,7 @@
 package network
 
 import (
+	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/fabric/controller/db"
 	"github.com/openziti/fabric/controller/models"
 	"github.com/openziti/foundation/channel2"
@@ -169,6 +170,12 @@ func (ctrl *RouterController) readInTx(tx *bbolt.Tx, id string) (*Router, error)
 	return entity, nil
 }
 
-func(ctrl *RouterController) ClearCache(id string) {
-	ctrl.cache.Remove(id)
+func (ctrl *RouterController) UpdateCachedFingerprint(id, fingerprint string) {
+	if val, ok := ctrl.cache.Get(id); ok {
+		if router, ok := val.(*Router); ok {
+			router.Fingerprint = &fingerprint
+		} else {
+			pfxlog.Logger().Errorf("encountered %t in router cache, expected *Router", val)
+		}
+	}
 }

--- a/controller/network/router.go
+++ b/controller/network/router.go
@@ -168,3 +168,7 @@ func (ctrl *RouterController) readInTx(tx *bbolt.Tx, id string) (*Router, error)
 	ctrl.cache.Set(id, entity)
 	return entity, nil
 }
+
+func(ctrl *RouterController) ClearCache(id string) {
+	ctrl.cache.Remove(id)
+}


### PR DESCRIPTION
Will be used for enrollment extension where the fingerprint has been updated