### PR TITLE
Fix for GetCircuit Initialization Vulnerability

### DIFF
--- a/router/xgress/request.go
+++ b/router/xgress/request.go
@@ -137,6 +137,10 @@ type CircuitInfo struct {
 var circuitError = errors.New("error connecting circuit")
 
 func GetCircuit(ctrl CtrlChannel, ingressId string, serviceId string, timeout time.Duration, peerData map[uint32][]byte) (*CircuitInfo, error) {
+	if ctrl == nil || ctrl.Channel() == channel2.Channel(nil) {
+		return nil, errors.New("ctrl not ready")
+	}
+
 	log := pfxlog.Logger()
 	circuitRequest := &ctrl_pb.CircuitRequest{
 		IngressId: ingressId,


### PR DESCRIPTION
A customer is experiencing a cyclic crash with a `nil` pointer issue in `xgress.GetCircuit`. Most likely due to a request coming in before all of the internal wiring can be established. This fix will return a failure to the client until the internals are fully online.