### PR TITLE
Close send buffer when unrouted, since sends will no longer work

### DIFF
--- a/router/xgress/xgress.go
+++ b/router/xgress/xgress.go
@@ -261,6 +261,7 @@ func (self *Xgress) Unrouted() {
 	// When we're unrouted, if end of circuit hasn't already arrived, give incoming/queued data
 	// a chance to outflow before closing
 	if !self.flags.IsSet(closedFlag) {
+		self.payloadBuffer.Close()
 		time.AfterFunc(self.Options.MaxCloseWait, self.Close)
 	}
 }


### PR DESCRIPTION
I tested this by adding a 100ms delay to the ack sender. I was able to see the log spam every time. This fixes it, and I believe should be safe. Since we've been unrouted (which we only do after the circuit is closed), sends will never work again, so we might as well shutdown the send buffer