### PR TITLE
Add routing perf benchmark and improve router perf

### DIFF
--- a/controller/network/link_controller_test.go
+++ b/controller/network/link_controller_test.go
@@ -36,21 +36,21 @@ func TestLifecycle(t *testing.T) {
 	linkController.add(l0)
 	assert.True(t, linkController.has(l0))
 
-	links := linkController.allLinksForRouter(r0.Id)
+	links := r0.routerLinks.GetLinks()
 	assert.Equal(t, 1, len(links))
 	assert.Equal(t, l0, links[0])
 
-	links = linkController.allLinksForRouter(r1.Id)
+	links = r1.routerLinks.GetLinks()
 	assert.Equal(t, 1, len(links))
 	assert.Equal(t, l0, links[0])
 
 	linkController.remove(l0)
 	assert.False(t, linkController.has(l0))
 
-	links = linkController.allLinksForRouter(r0.Id)
+	links = r0.routerLinks.GetLinks()
 	assert.Equal(t, 0, len(links))
 
-	links = linkController.allLinksForRouter(r1.Id)
+	links = r1.routerLinks.GetLinks()
 	assert.Equal(t, 0, len(links))
 }
 

--- a/controller/network/network.go
+++ b/controller/network/network.go
@@ -193,7 +193,11 @@ func (network *Network) GetAllLinks() []*Link {
 }
 
 func (network *Network) GetAllLinksForRouter(routerId string) []*Link {
-	return network.linkController.allLinksForRouter(routerId)
+	r := network.GetConnectedRouter(routerId)
+	if r == nil {
+		return nil
+	}
+	return r.routerLinks.GetLinks()
 }
 
 func (network *Network) GetCircuit(circuitId string) (*Circuit, bool) {
@@ -291,7 +295,7 @@ func (network *Network) ValidateTerminators(r *Router) {
 
 func (network *Network) DisconnectRouter(r *Router) {
 	// 1: remove Links for Router
-	for _, l := range network.linkController.allLinksForRouter(r.Id) {
+	for _, l := range r.routerLinks.GetLinks() {
 		network.linkController.remove(l)
 		network.LinkChanged(l)
 	}
@@ -930,13 +934,13 @@ func (network *Network) GetServiceCache() Cache {
 
 func (network *Network) NotifyRouterRenamed(id, name string) {
 	if cached, _ := network.Routers.cache.Get(id); cached != nil {
-		if cachedRouter, ok := cached.(*db.Router); ok {
+		if cachedRouter, ok := cached.(*Router); ok {
 			cachedRouter.Name = name
 		}
 	}
 
 	if cached, _ := network.Routers.connected.Get(id); cached != nil {
-		if cachedRouter, ok := cached.(*db.Router); ok {
+		if cachedRouter, ok := cached.(*Router); ok {
 			cachedRouter.Name = name
 		}
 	}

--- a/controller/network/path.go
+++ b/controller/network/path.go
@@ -176,6 +176,9 @@ func (network *Network) shortestPath(srcR *Router, dstR *Router) ([]*Router, int
 
 	for len(unvisited) > 0 {
 		u := minCost(unvisited, dist)
+		if u == dstR { // if the dest router is the lowest cost next link, we can stop evaluating
+			break
+		}
 		delete(unvisited, u)
 
 		neighbors := network.linkController.connectedNeighborsOfRouter(u)

--- a/controller/network/util_test.go
+++ b/controller/network/util_test.go
@@ -123,7 +123,7 @@ func debugNetwork(n *Network) {
 
 	for rIdx, router := range routers {
 		debugf("%v router: %v\n", rIdx, router.Id)
-		links := n.linkController.allLinksForRouter(router.Id)
+		links := router.routerLinks.GetLinks()
 		sort.Slice(links, func(i, j int) bool {
 			return links[i].Id.Token < links[j].Id.Token
 		})


### PR DESCRIPTION
// original
BenchmarkShortestPathPerf-16    	       1	3773070830 ns/op
BenchmarkShortestPathPerf-16    	       1	3825162708 ns/op
BenchmarkShortestPathPerf-16    	       1	3657423204 ns/op
BenchmarkShortestPathPerf-16    	       1	3850618501 ns/op

// with pre-sized link slice
BenchmarkShortestPathPerf-16    	       1	3527057280 ns/op
BenchmarkShortestPathPerf-16    	       1	3532569248 ns/op
BenchmarkShortestPathPerf-16    	       1	3830881675 ns/op

// going straight to link slice
BenchmarkShortestPathPerf-16    	       1	2776857287 ns/op
BenchmarkShortestPathPerf-16    	       1	2769336745 ns/op
BenchmarkShortestPathPerf-16    	       1	2772600435 ns/op
BenchmarkShortestPathPerf-16    	       1	2918562399 ns/op

// using COW map of connected routers
no real change

// with router stored COW slices of related links
BenchmarkShortestPathPerf-16    	1000000000	         0.09486 ns/op
BenchmarkShortestPathPerf-16    	1000000000	         0.07627 ns/op
BenchmarkShortestPathPerf-16    	1000000000	         0.08958 ns/op
BenchmarkShortestPathPerf-16    	1000000000	         0.1065 ns/op

// With short-circuited Dijkstra 
BenchmarkShortestPathPerf-16    	1000000000	         0.05746 ns/op
BenchmarkShortestPathPerf-16    	1000000000	         0.05734 ns/op
BenchmarkShortestPathPerf-16    	1000000000	         0.05560 ns/op
BenchmarkShortestPathPerf-16    	1000000000	         0.05702 ns/op
