### PR TITLE
adds gzip, br, and deflate support to xweb servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ go 1.17
 require (
 	github.com/AppsFlyer/go-sundheit v0.4.0
 	github.com/Jeffail/gabs/v2 v2.6.1
+	github.com/andybalholm/brotli v1.0.4
 	github.com/ef-ds/deque v1.0.4
 	github.com/emirpasic/gods v1.12.0
 	github.com/go-resty/resty/v2 v2.7.0

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
+github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
+github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20211106181442-e4c1a74c66bd h1:fjJY1LimH0wVCvOHLX35SCX/MbWomAglET1H2kvz7xc=

--- a/xweb/middleware/compression.go
+++ b/xweb/middleware/compression.go
@@ -1,0 +1,256 @@
+/*
+	Copyright NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package middleware
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"fmt"
+	"github.com/andybalholm/brotli"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+type HttpEncoding string
+
+const (
+	HttpHeaderContentLength   = "Content-Length"
+	HttpHeaderAcceptEncoding  = "Accept-Encoding"
+	HttpHeaderContentEncoding = "Content-Encoding"
+
+	HttpEncodingGzip     = HttpEncoding("gzip")
+	HttpEncodingBr       = HttpEncoding("br")
+	HttpEncodingDeflate  = HttpEncoding("deflate")
+	HttpEncodingIdentity = HttpEncoding("identity")
+)
+
+var supportedEncodings = map[HttpEncoding]struct{}{
+	HttpEncodingGzip:    {},
+	HttpEncodingBr:      {},
+	HttpEncodingDeflate: {},
+}
+
+var gzPool = sync.Pool{
+	New: func() interface{} {
+		w := gzip.NewWriter(ioutil.Discard)
+		return w
+	},
+}
+
+var brPool = sync.Pool{
+	New: func() interface{} {
+		w := brotli.NewWriter(ioutil.Discard)
+		return w
+	},
+}
+
+var deflatePool = sync.Pool{
+	New: func() interface{} {
+		w, _ := flate.NewWriter(ioutil.Discard, 4)
+		return w
+	},
+}
+
+// NewCompressionHandler will return a http.Handler that should be at the top of a response pipeline (i.e. before any
+// other http.handlers that write). The returned handler will handle accept-encoding http header interpretation and
+// provide a wrapped writer to all downstream http.handlers that will result in all written content to be compressed if
+// possible.
+//
+// The handler will alter the http responses content encoding header (specified algorithm), content body (compressed),
+// and content length header (to match compressed body size). Attempting to set any of these values or alter the
+// content response body (including writing more data) after the handler exits may cause issues for the receiving
+// client.
+func NewCompressionHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		acceptEncodingHeader := getSupportedAcceptEncoding(r)
+
+		switch acceptEncodingHeader {
+		case HttpEncodingGzip:
+			handleGZip(w, r, next)
+			return
+		case HttpEncodingBr:
+			handleBr(w, r, next)
+			return
+		case HttpEncodingDeflate:
+			handleDeflate(w, r, next)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// getSupportedAcceptEncoding returns the highest priority supported encoding supplied by the client.
+// HttpEncodingIdentity (no encoding) is returned if no accept header is supplied, invalid headers are supplied, or
+// no supported encodings are supplied.
+func getSupportedAcceptEncoding(r *http.Request) HttpEncoding {
+	rawHeaders := r.Header.Values(HttpHeaderAcceptEncoding)
+
+	highestSupported := HttpEncodingIdentity
+	highestQFactor := float32(-1)
+
+	for _, rawHeader := range rawHeaders {
+		rawWeightedHeaders := strings.Split(rawHeader, ",")
+
+		for _, rawWeightedHeader := range rawWeightedHeaders {
+			rawWeightedHeader = strings.TrimSpace(rawWeightedHeader)
+			rawWeightedSplits := strings.Split(rawWeightedHeader, ";")
+
+			encoding := HttpEncoding(strings.TrimSpace(rawWeightedSplits[0]))
+			qFactor := float32(1) //if not specified, 1 is default
+
+			_, isSupported := supportedEncodings[encoding]
+
+			if isSupported {
+				// if 2+, we have a qFactor
+				if len(rawWeightedSplits) > 1 {
+					rawWeight := strings.TrimSpace(rawWeightedSplits[1])
+
+					if !strings.HasPrefix(rawWeight, "q=") {
+						continue //we can't parse this, it isn't a weight, give up on the value
+					}
+
+					rawWeight = strings.TrimPrefix(rawWeight, "q=")
+
+					if parsedQFactor, err := strconv.ParseFloat(rawWeight, 32); err == nil {
+						qFactor = float32(parsedQFactor)
+					} else {
+						continue //value isn't a parsable float, give up
+					}
+				}
+
+				//qFactors are 0.0-1.0 values only
+				if qFactor >= 0 && qFactor <= 1 && qFactor > highestQFactor {
+					highestSupported = encoding
+					highestQFactor = qFactor
+				}
+			}
+		}
+	}
+	return highestSupported
+}
+
+// wrappedResponseWriter satisfies http.ResponseWriter and allows the compression handler to redirect
+// Write() calls to compression encoder instead of the actual http.ResponseWriter.
+type wrappedResponseWriter struct {
+	status int
+	io.Writer
+	http.ResponseWriter
+}
+
+// WriteHeader delays writing the status header till after compression is complete. This is done
+// so that the content length header can be properly set. Prematurely calling WriteHeader()
+// will cause all subsequent header changes to not be applied.
+func (w *wrappedResponseWriter) WriteHeader(status int) {
+	w.status = status
+}
+
+// Write proxies the normal Write() to instead run through the compression encoder. Actual writing
+// to the http.ResponseWriter is handled via a defer'ed function call.
+func (w *wrappedResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+// CloseHeaderSection is used by the encoder specific function handler to apply the
+// requested HTTP status and close the header section. This is called during the encoders
+// defer'ed section to occur after all content is written. Emulates
+// net/https default http.StatusOk value.
+func (w *wrappedResponseWriter) CloseHeaderSection() {
+	if w.status == 0 {
+		//emulate default status ok behaviour
+		w.status = http.StatusOK
+	}
+	w.ResponseWriter.WriteHeader(w.status)
+}
+
+// handleGZip pulls a gzip encoder from the pool encoders and sets it as the writer
+// for the response. The next http.Handler is then invoked and when finished
+// a deferred function will then pull the compressed contents out of the encoder
+// and set the appropriate http headers.
+func handleGZip(w http.ResponseWriter, r *http.Request, next http.Handler) {
+	gz := gzPool.Get().(*gzip.Writer)
+	defer gzPool.Put(gz)
+
+	var b bytes.Buffer
+	gz.Reset(&b)
+
+	wrappedWriter := &wrappedResponseWriter{ResponseWriter: w, Writer: gz}
+
+	defer func() {
+		_ = gz.Close()
+		length := len(b.Bytes())
+		w.Header().Set(HttpHeaderContentEncoding, string(HttpEncodingGzip))
+		w.Header().Set(HttpHeaderContentLength, fmt.Sprint(length))
+		wrappedWriter.CloseHeaderSection()
+		_, _ = w.Write(b.Bytes())
+	}()
+
+	next.ServeHTTP(wrappedWriter, r)
+}
+
+// handleDeflate pulls a deflate encoder from the pool encoders and sets it as the writer
+// for the response. The next http.Handler is then invoked and when finished
+// a deferred function will then pull the compressed contents out of the encoder
+// and set the appropriate http headers.
+func handleDeflate(w http.ResponseWriter, r *http.Request, next http.Handler) {
+	deflate := deflatePool.Get().(*flate.Writer)
+	defer deflatePool.Put(deflate)
+
+	var b bytes.Buffer
+	deflate.Reset(&b)
+
+	wrappedWriter := &wrappedResponseWriter{ResponseWriter: w, Writer: deflate}
+
+	defer func() {
+		_ = deflate.Close()
+		w.Header().Set(HttpHeaderContentEncoding, string(HttpEncodingDeflate))
+		w.Header().Set(HttpHeaderContentLength, fmt.Sprint(len(b.Bytes())))
+		wrappedWriter.CloseHeaderSection()
+		_, _ = w.Write(b.Bytes())
+	}()
+
+	next.ServeHTTP(wrappedWriter, r)
+}
+
+// handleBr pulls a brotli encoder from the pool encoders and sets it as the writer
+// for the response. The next http.Handler is then invoked and when finished
+// a deferred function will then pull the compressed contents out of the encoder
+// and set the appropriate http headers.
+func handleBr(w http.ResponseWriter, r *http.Request, next http.Handler) {
+	w.Header().Set(HttpHeaderContentEncoding, string(HttpEncodingBr))
+
+	br := brPool.Get().(*brotli.Writer)
+	defer brPool.Put(br)
+
+	var b bytes.Buffer
+	br.Reset(&b)
+
+	wrappedWriter := &wrappedResponseWriter{ResponseWriter: w, Writer: br}
+
+	defer func() {
+		_ = br.Close()
+		w.Header().Set(HttpHeaderContentLength, fmt.Sprint(len(b.Bytes())))
+		_, _ = w.Write(b.Bytes())
+	}()
+
+	next.ServeHTTP(wrappedWriter, r)
+}

--- a/xweb/middleware/compression_test.go
+++ b/xweb/middleware/compression_test.go
@@ -1,0 +1,359 @@
+package middleware
+
+import (
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
+)
+
+func Test_getSupportedAcceptEncoding(t *testing.T) {
+
+	t.Run("returns HttpEncodingIdentity if accept encodings are not specified", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingIdentity, encoding)
+	})
+
+	t.Run("returns HttpEncodingIdentity if accept encodings are not supported, well formatted", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {"abc,one;q=0,two,three"},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingIdentity, encoding)
+	})
+
+	t.Run("returns HttpEncodingIdentity if accept encodings are not supported, not well formatted", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {"a,b;;;;;q="},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingIdentity, encoding)
+	})
+
+	t.Run("returns HttpEncodingIdentity if accept encodings has gzip, not well formatted", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {"a,b;;;;;q=,gzip"},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingGzip, encoding)
+	})
+
+	t.Run("returns HttpEncodingGzip if supplied as: gzip", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingGzip)},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingGzip, encoding)
+	})
+
+	t.Run("returns HttpEncodingIdentity if supplied as: gzip, q>1", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingGzip) + ";q=1.1"},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingIdentity, encoding)
+	})
+
+	t.Run("returns HttpEncodingIdentity if supplied as: gzip, q<0", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingGzip) + ";q=-0.1"},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingIdentity, encoding)
+	})
+
+	t.Run("returns HttpEncodingIdentity if supplied as: gzip, non-float q", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingGzip) + ";q=abc"},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingIdentity, encoding)
+	})
+
+	t.Run("returns HttpEncodingIdentity if supplied as: gzip, q is empty", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingGzip) + ";q="},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingIdentity, encoding)
+	})
+
+	t.Run("returns HttpEncodingBr if supplied as: br/gzip, multiple headers, no q factors", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingBr), string(HttpEncodingGzip)},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingBr, encoding)
+	})
+
+	t.Run("returns HttpEncodingBr if supplied as: br/gzip, one header, no q factors", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingBr) + "," + string(HttpEncodingGzip)},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingBr, encoding)
+	})
+
+	t.Run("returns HttpEncodingBr if supplied as: br/gzip/deflate, multiple mixed header, no q factors", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {
+					string(HttpEncodingBr),
+					string(HttpEncodingDeflate) + "," + string(HttpEncodingGzip)},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingBr, encoding)
+	})
+
+	t.Run("returns HttpEncodingBr if supplied as: br/gzip/deflate, multiple mixed header, q factors, last header q=1 explicit", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {
+					string(HttpEncodingDeflate) + ";q=0.5" + "," + string(HttpEncodingGzip) + ";q=0.2",
+					string(HttpEncodingBr) + ";q=1",
+				},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingBr, encoding)
+	})
+
+	t.Run("returns HttpEncodingBr if supplied as: br/gzip/deflate, multiple mixed header, q factors, last header q=1 implicit", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {
+					string(HttpEncodingDeflate) + ";q=0.5" + "," + string(HttpEncodingBr) + ";q=0.2",
+					string(HttpEncodingGzip), //implicit q=1
+				},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingGzip, encoding)
+	})
+
+	t.Run("returns HttpEncodingBr if supplied as: br/gzip/deflate, unsupported encodings, multiple mixed header, q factors, middle header q=1 implicit", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {
+					"text/html;q=1",
+					string(HttpEncodingDeflate) + ";q=0.9" + "," + string(HttpEncodingBr) + ";q=0.99",
+					string(HttpEncodingGzip), //implicit q=1
+					"text/xml",
+					"ambulance;q=1,quiver;q=1,doctor",
+				},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingGzip, encoding)
+	})
+
+	t.Run("returns HttpEncodingBr if supplied as: br/gzip/deflate, unsupported encodings, multiple mixed header, q factors, middle header q=1 explicit", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {
+					"text/html;q=1",
+					string(HttpEncodingDeflate) + ";q=0.9" + "," + string(HttpEncodingBr) + ";q=0.99",
+					string(HttpEncodingGzip) + ";q=1,random;q=1,wierd", //implicit q=1
+					"text/xml",
+					"ambulance;q=1,quiver;q=1,doctor",
+				},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingGzip, encoding)
+	})
+
+	// gzip positive tests
+
+	t.Run("returns HttpEncodingGzip if supplied as: gzip;q=0", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingGzip) + ";q=0"},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingGzip, encoding)
+	})
+
+	t.Run("returns HttpEncodingGzip if supplied as: gzip;q=1", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingGzip) + ";q=1"},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingGzip, encoding)
+	})
+
+	t.Run("returns HttpEncodingGzip if supplied as: gzip;q=0.5", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingGzip) + ";q=1"},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingGzip, encoding)
+	})
+
+	// br - positive tests
+
+	t.Run("returns HttpEncodingBr if supplied as: br;q=0", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingBr) + ";q=0"},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingBr, encoding)
+	})
+
+	t.Run("returns HttpEncodingBr if supplied as: br;q=1", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingBr) + ";q=1"},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingBr, encoding)
+	})
+
+	t.Run("returns HttpEncodingBr if supplied as: br;q=0.5", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingBr) + ";q=1"},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingBr, encoding)
+	})
+
+	// deflate - positive tests
+
+	t.Run("returns HttpEncodingDeflate if supplied as: deflate;q=0", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingDeflate) + ";q=0"},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingDeflate, encoding)
+	})
+
+	t.Run("returns HttpEncodingDeflate if supplied as: deflate;q=1", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingDeflate) + ";q=1"},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingDeflate, encoding)
+	})
+
+	t.Run("returns HttpEncodingDeflate if supplied as: deflate;q=0.5", func(t *testing.T) {
+		req := require.New(t)
+		r := &http.Request{
+			Header: map[string][]string{
+				HttpHeaderAcceptEncoding: {string(HttpEncodingDeflate) + ";q=1"},
+			},
+		}
+
+		encoding := getSupportedAcceptEncoding(r)
+
+		req.Equal(HttpEncodingDeflate, encoding)
+	})
+}

--- a/xweb/server.go
+++ b/xweb/server.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"github.com/michaelquigley/pfxlog"
+	"github.com/openziti/fabric/xweb/middleware"
 	"github.com/openziti/foundation/util/debugz"
 	"io"
 	"log"
@@ -139,9 +140,10 @@ func NewServer(webListener *WebListener, demuxFactory DemuxFactory, handlerFacto
 }
 
 func (server *Server) wrapHandler(_ *WebListener, point *BindPoint, handler http.Handler) http.Handler {
-	handler = server.wrapPanicRecovery(handler)
+	//innermost/bottom -> outermost/top
 	handler = server.wrapSetCtrlAddressHeader(point, handler)
-
+	handler = server.wrapPanicRecovery(handler)
+	handler = middleware.NewCompressionHandler(handler)
 	return handler
 }
 


### PR DESCRIPTION
- all xweb http.Server's now have compression support
- supports multiple weighted Accept-Encoding headers
- uses pools of encoders to reduce memory churn under load
- adds wrapped http.ResponseWriter to delay header closing before
  compression and content length can be set