### PR TITLE
add backtrace

### DIFF
--- a/router/handler_ctrl/bind.go
+++ b/router/handler_ctrl/bind.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openziti/foundation/v2/goroutines"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"runtime/debug"
 	"time"
 )
 
@@ -52,7 +53,7 @@ func (self *bindHandler) BindChannel(binding channel.Binding) error {
 		IdleTime:    30 * time.Second,
 		CloseNotify: self.env.GetCloseNotify(),
 		PanicHandler: func(err interface{}) {
-			pfxlog.Logger().WithField(logrus.ErrorKey, err).Error("panic during link dial")
+			pfxlog.Logger().WithField(logrus.ErrorKey, err).WithField("backtrace", string(debug.Stack())).Error("panic during link dial")
 		},
 	}
 
@@ -70,7 +71,7 @@ func (self *bindHandler) BindChannel(binding channel.Binding) error {
 		IdleTime:    30 * time.Second,
 		CloseNotify: self.env.GetCloseNotify(),
 		PanicHandler: func(err interface{}) {
-			pfxlog.Logger().WithField(logrus.ErrorKey, err).Error("panic during xgress dial")
+			pfxlog.Logger().WithField(logrus.ErrorKey, err).WithField("backtrace", string(debug.Stack())).Error("panic during xgress dial")
 		},
 	}
 


### PR DESCRIPTION
Sample output:
```
[55477.402]   ERROR fabric/router/handler_ctrl.(*bindHandler).BindChannel.func2: {error=[runtime error: invalid memory address or nil pointer dereference] backtrace=[goroutine 220 [running]:
runtime/debug.Stack()
	/home/eugene/go/go1.18.2/src/runtime/debug/stack.go:24 +0x7a
github.com/openziti/fabric/router/handler_ctrl.(*bindHandler).BindChannel.func2({0x2781520, 0x38695d0})
	/home/eugene/work/ziti-work/fabric/router/handler_ctrl/bind.go:74 +0x78
github.com/openziti/foundation/v2/goroutines.(*pool).worker.func1()
	/home/eugene/go/pkg/mod/github.com/openziti/foundation/v2@v2.0.1/goroutines/pool.go:177 +0x66
panic({0x2781520, 0x38695d0})
	/home/eugene/go/go1.18.2/src/runtime/panic.go:844 +0x25a
github.com/openziti/edge/router/xgress_edge_tunnel.(*tunneler).Dial(0xc0000eb650, {0xc000054930, 0x24}, 0xc000327080, {0xc000bee0d8, 0x4}, {0x2d22820, 0xc000063200}, {0x2d3c0d8, 0xc000419470}, ...)
	/home/eugene/work/ziti-work/edge/router/xgress_edge_tunnel/dialer.go:72 +0x8a1
github.com/openziti/fabric/router/handler_ctrl.(*routeHandler).connectEgress(0xc000548540, 0xc000326c60, 0x1, {0x2d426b8, 0xc0001b0900}, 0xc0000eafc0, {0x2d3c0d8, 0xc000419470}, {0xc0ac393d57cc6e43, 0x461e4097a, ...})
	/home/eugene/work/ziti-work/fabric/router/handler_ctrl/route.go:172 +0xb35
github.com/openziti/fabric/router/handler_ctrl.(*routeHandler).HandleReceive.func1()
	/home/eugene/work/ziti-work/fabric/router/handler_ctrl/route.go:97 +0x2ee
github.com/openziti/foundation/v2/goroutines.(*pool).runWork(0xc000484910, 0xc000484500)
	/home/eugene/go/pkg/mod/github.com/openziti/foundation/v2@v2.0.1/goroutines/pool.go:243 +0xdf
github.com/openziti/foundation/v2/goroutines.(*pool).worker(0xc000484910, 0x0)
	/home/eugene/go/pkg/mod/github.com/openziti/foundation/v2@v2.0.1/goroutines/pool.go:199 +0x33c
created by github.com/openziti/foundation/v2/goroutines.(*pool).tryAddWorker
	/home/eugene/go/pkg/mod/github.com/openziti/foundation/v2@v2.0.1/goroutines/pool.go:231 +0xb1
]} panic during xgress dial
```