### PR TITLE
Readonly lock

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -20,6 +20,8 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/michaelquigley/pfxlog"
 	"github.com/openziti/channel"
 	"github.com/openziti/fabric/controller/api_impl"
@@ -47,7 +49,6 @@ import (
 	"github.com/openziti/storage/boltz"
 	"github.com/openziti/xweb/v2"
 	"github.com/sirupsen/logrus"
-	"time"
 )
 
 type Controller struct {
@@ -125,7 +126,7 @@ func NewController(cfg *Config, versionProvider versions.VersionProvider) (*Cont
 	}
 
 	if cfg.Raft != nil {
-		raftController, err := raft.NewController(cfg.Id, cfg.Raft, metricRegistry)
+		raftController, err := raft.NewController(cfg.Id, versionProvider.Version(), cfg.Raft, metricRegistry)
 		if err != nil {
 			log.WithError(err).Panic("error starting raft")
 		}

--- a/controller/raft/mesh/mesh_test.go
+++ b/controller/raft/mesh/mesh_test.go
@@ -1,0 +1,133 @@
+package mesh
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_checkState_ReadonlyFalseWhenAllVersionsMatch(t *testing.T) {
+	ro := &atomic.Bool{}
+	ro.Store(false)
+	m := impl{
+		readonly: ro,
+		Peers: map[string]*Peer{
+			"1": {Version: "1", Address: "1"},
+			"2": {Version: "1", Address: "2"},
+		},
+		version: "1",
+	}
+
+	m.checkState()
+	assert.Equal(t, false, m.readonly.Load(), "Expected readonly to be false, got ", m.readonly.Load())
+}
+
+func Test_checkState_ReadonlyTrueWhenAllVersionsDoNotMatch(t *testing.T) {
+	ro := &atomic.Bool{}
+	ro.Store(false)
+	m := impl{
+		readonly: ro,
+		Peers: map[string]*Peer{
+			"1": {Version: "dne", Address: "1"},
+			"2": {Version: "dne", Address: "2"},
+		},
+		version: "1",
+	}
+
+	m.checkState()
+	assert.Equal(t, true, m.readonly.Load(), "Expected readonly to be true, got ", m.readonly.Load())
+}
+
+func Test_checkState_ReadonlySetToFalseWhenPreviouslyTrueAndAllVersionsNowMatch(t *testing.T) {
+	ro := &atomic.Bool{}
+	ro.Store(true)
+	m := impl{
+		readonly: ro,
+		Peers: map[string]*Peer{
+			"1": {Version: "1", Address: "1"},
+			"2": {Version: "1", Address: "2"},
+		},
+		version: "1",
+	}
+
+	m.checkState()
+	assert.Equal(t, false, m.readonly.Load(), "Expected readonly to be false, got ", m.readonly.Load())
+}
+
+func Test_AddPeer_PassesReadonlyWhenVersionsMatch(t *testing.T) {
+	ro := &atomic.Bool{}
+	ro.Store(false)
+	m := impl{
+		readonly: ro,
+		Peers:    map[string]*Peer{},
+		version:  "1",
+	}
+
+	p := &Peer{Version: "1"}
+
+	m.AddPeer(p)
+	assert.Equal(t, false, m.readonly.Load(), "Expected readonly to be false, got ", m.readonly.Load())
+}
+
+func Test_AddPeer_TurnsReadonlyWhenVersionsDoNotMatch(t *testing.T) {
+	ro := &atomic.Bool{}
+	ro.Store(false)
+	m := impl{
+		readonly: ro,
+		Peers:    map[string]*Peer{},
+		version:  "1",
+	}
+
+	p := &Peer{Version: "dne"}
+
+	m.AddPeer(p)
+	assert.Equal(t, true, m.readonly.Load(), "Expected readonly to be true, got ", m.readonly.Load())
+}
+
+func Test_RemovePeer_StaysReadonlyWhenDeletingPeerAndStillHasMismatchedVersions(t *testing.T) {
+	ro := &atomic.Bool{}
+	ro.Store(true)
+	m := impl{
+		readonly: ro,
+		Peers: map[string]*Peer{
+			"1": {Version: "dne", Address: "1"},
+			"2": {Version: "dne", Address: "2"},
+		},
+		version: "1",
+	}
+
+	m.RemovePeer(m.Peers["1"])
+	assert.Equal(t, true, m.readonly.Load(), "Expected readonly to be true, got ", m.readonly.Load())
+}
+
+func Test_RemovePeer_RemovesReadonlyWhenDeletingPeerWithNoOtherMismatches(t *testing.T) {
+	ro := &atomic.Bool{}
+	ro.Store(true)
+	m := impl{
+		readonly: ro,
+		Peers: map[string]*Peer{
+			"1": {Version: "dne", Address: "1"},
+			"2": {Version: "1", Address: "2"},
+		},
+		version: "1",
+	}
+
+	m.RemovePeer(m.Peers["1"])
+	assert.Equal(t, false, m.readonly.Load(), "Expected readonly to be false, got ", m.readonly.Load())
+}
+
+func Test_RemovePeer_RemovesReadonlyWhenDeletingLastPeer(t *testing.T) {
+	ro := &atomic.Bool{}
+	ro.Store(true)
+	m := impl{
+		readonly: ro,
+		Peers: map[string]*Peer{
+			"1": {Version: "dne", Address: "1"},
+		},
+		version: "1",
+	}
+
+	m.RemovePeer(m.Peers["1"])
+	assert.Equal(t, false, m.readonly.Load(), "Expected readonly to be false, got ", m.readonly.Load())
+}

--- a/controller/raft/raft.go
+++ b/controller/raft/raft.go
@@ -19,6 +19,14 @@ package raft
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"reflect"
+	"strconv"
+	"sync"
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/hashicorp/raft"
 	raftboltdb "github.com/hashicorp/raft-boltdb"
@@ -33,13 +41,6 @@ import (
 	"github.com/openziti/storage/boltz"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"io/fs"
-	"os"
-	"path"
-	"reflect"
-	"strconv"
-	"sync"
-	"time"
 )
 
 type Config struct {
@@ -54,12 +55,13 @@ type Config struct {
 	}
 }
 
-func NewController(id *identity.TokenId, config *Config, metricsRegistry metrics.Registry) (*Controller, error) {
+func NewController(id *identity.TokenId, version string, config *Config, metricsRegistry metrics.Registry) (*Controller, error) {
 	result := &Controller{
 		Id:              id,
 		Config:          config,
 		metricsRegistry: metricsRegistry,
 		indexTracker:    NewIndexTracker(),
+		version:         version,
 	}
 	if err := result.Init(); err != nil {
 		return nil, err
@@ -81,6 +83,7 @@ type Controller struct {
 	metricsRegistry metrics.Registry
 	closeNotify     <-chan struct{}
 	indexTracker    IndexTracker
+	version         string
 }
 
 // GetRaft returns the managed raft instance
@@ -117,6 +120,10 @@ func (self *Controller) Dispatch(cmd command.Command) error {
 		if err := validatable.Validate(); err != nil {
 			return err
 		}
+	}
+
+	if self.Mesh.IsReadOnly() {
+		return fmt.Errorf("Unable to execute command. In a readonly state.")
 	}
 
 	if self.IsLeader() {
@@ -337,7 +344,7 @@ func (self *Controller) Init() error {
 		return nil
 	}
 
-	self.Mesh = mesh.New(self.Id, conf.LocalID, localAddr, channel.BindHandlerF(bindHandler))
+	self.Mesh = mesh.New(self.Id, self.version, conf.LocalID, localAddr, channel.BindHandlerF(bindHandler))
 
 	transport := raft.NewNetworkTransportWithLogger(self.Mesh, 3, 10*time.Second, hclLogger)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openziti/fabric
 
-go 1.18
+go 1.19
 
 require (
 	github.com/AppsFlyer/go-sundheit v0.5.0


### PR DESCRIPTION
Added a readonly lock to prevent commands being run by mismatched controllers.

Up'd the go version to 1.19 to take advantage of new typed atomics.