### PR TITLE
Adding additional info fields to swagger spec

### DIFF
--- a/specs/swagger.yml
+++ b/specs/swagger.yml
@@ -3,7 +3,14 @@ swagger: '2.0'
 info:
   version: 0.16.54
   title: Ziti Fabric
-  contact: {}
+  description: OpenZiti Fabric API
+  contact:
+    name: OpenZiti
+    url: https://openziti.discourse.group
+    email: help@openziti.org
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 host: demo.ziti.dev
 basePath: /fabric/v1
 schemes:


### PR DESCRIPTION
The additional `info` fields are used by [openapi-generator](https://github.com/OpenAPITools/openapi-generator) client generators for things like module documentation, and packaging scripts.

Example: [setup.py](https://github.com/OpenAPITools/openapi-generator/blob/5300bff6d96adfcfdd0db25b77ecb51532264575/modules/openapi-generator/src/main/resources/python-prior/setup.mustache)