### PR TITLE
add ability to use shared TLS listeners

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"github.com/openziti/fabric/config"
 	"github.com/openziti/fabric/controller/handler_peer_ctrl"
+	"github.com/openziti/transport/v2"
 	"os"
 	"sync/atomic"
 	"time"
@@ -244,6 +245,7 @@ func (c *Controller) Run() error {
 		ConnectOptions:   c.config.Ctrl.Options.ConnectOptions,
 		PoolConfigurator: fabricMetrics.GoroutinesPoolMetricsConfigF(c.network.GetMetricsRegistry(), "pool.listener.ctrl"),
 		Headers:          headers,
+		TransportConfig:  transport.Configuration{"protocol": "ziti-ctrl"},
 	}
 	ctrlListener := channel.NewClassicListener(c.config.Id, c.config.Ctrl.Listener, ctrlChannelListenerConfig)
 	c.ctrlListener = ctrlListener

--- a/router/router.go
+++ b/router/router.go
@@ -425,6 +425,7 @@ func (self *Router) startXlinkListeners() {
 	for _, lmap := range self.config.Link.Listeners {
 		binding := lmap["binding"].(string)
 		if factory, found := self.xlinkFactories[binding]; found {
+			lmap["protocol"] = "ziti-link"
 			listener, err := factory.CreateListener(self.config.Id, self.forwarder, lmap)
 			if err != nil {
 				logrus.Fatalf("error creating Xlink listener (%v)", err)
@@ -549,7 +550,8 @@ func (self *Router) connectToController(addr transport.Address, bindHandler chan
 	dialer := channel.NewReconnectingDialerWithHandlerAndLocalBinding(self.config.Id, addr, self.config.Ctrl.LocalBinding, attributes, reconnectHandler)
 
 	bindHandler = channel.BindHandlers(bindHandler, self.ctrlBindhandler)
-	ch, err := channel.NewChannel("ctrl", dialer, bindHandler, self.config.Ctrl.Options)
+	tcfg := transport.Configuration{"protocol": "ziti-ctrl"}
+	ch, err := channel.NewChannelWithTransportConfiguration("ctrl", dialer, bindHandler, self.config.Ctrl.Options, tcfg)
 	if err != nil {
 		return fmt.Errorf("error connecting ctrl (%v)", err)
 	}

--- a/router/xlink_transport/factory.go
+++ b/router/xlink_transport/factory.go
@@ -52,10 +52,18 @@ func NewFactory(accepter xlink.Acceptor,
 	c transport.Configuration,
 	xlinkRegistry xlink.Registry,
 	metricsRegistry metrics.Registry) xlink.Factory {
+
+	cfg := make(transport.Configuration)
+	for k, v := range c {
+		cfg[k] = v
+	}
+
+	cfg["protocol"] = append(c.Protocols(), "ziti-link")
+
 	return &factory{
 		acceptor:           accepter,
 		bindHandlerFactory: bindHandlerFactory,
-		transportConfig:    c,
+		transportConfig:    cfg,
 		xlinkRegistry:      xlinkRegistry,
 		metricsRegistry:    metricsRegistry,
 	}

--- a/tests/control.go
+++ b/tests/control.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"github.com/openziti/channel/v2"
 	"github.com/openziti/fabric/controller"
+	"github.com/openziti/transport/v2"
 )
 
 func (ctx *TestContext) NewControlChannelListener() channel.UnderlayListener {
@@ -16,8 +17,9 @@ func (ctx *TestContext) NewControlChannelListener() channel.UnderlayListener {
 	}
 
 	ctrlChannelListenerConfig := channel.ListenerConfig{
-		ConnectOptions: config.Ctrl.Options.ConnectOptions,
-		Headers:        headers,
+		ConnectOptions:  config.Ctrl.Options.ConnectOptions,
+		Headers:         headers,
+		TransportConfig: transport.Configuration{"protocol": "ziti-ctrl"},
 	}
 	ctrlListener := channel.NewClassicListener(config.Id, config.Ctrl.Listener, ctrlChannelListenerConfig)
 	ctx.Req.NoError(ctrlListener.Listen())


### PR DESCRIPTION
two protocols(for ALPN purposes) are defined:
- ziti-ctrl: control channel marker
- ziti-link: link channel marker